### PR TITLE
Updating references of drs-data-dashboard to dashboard-ui.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# drs-data-dashboard
+# dashboard-ui
 A tool to report and visualize vital, high-level data points about the Harvard Library Digital Repository Service (DRS)
 
 ## Technology Stack
@@ -14,7 +14,7 @@ Docker Compose
 ## Local Development Environment Setup Instructions
 
 ### 1: Clone the repository to a local directory
-```git clone git@github.com:harvard-lts/drs-data-dashboard.git```
+```git clone git@github.com:harvard-lts/dashboard-ui.git```
 
 ### 2: Copy the cloned files into your own new project repository
 
@@ -47,7 +47,7 @@ This step is only required if additional python packages must be installed durin
 Open a shell using the exec command to access the hgl-downloader container.
 
 ```
-docker exec -it drs-data-dashboard bash
+docker exec -it dashboard-ui bash
 ```
 
 ##### Install a new pip package

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -5,8 +5,8 @@ version: '3.8'
 
 services:
 
-  drs-data-dashboard:
-    container_name: 'drs-data-dashboard'
+  dashboard-ui:
+    container_name: 'dashboard-ui'
     build:
       context: './'
       dockerfile: 'DockerfileLocal'
@@ -18,10 +18,10 @@ services:
       - '3001:8081'
     # Join this service to a custom docker network
     networks:
-      - drs-data-dashboard-net
+      - dashboard-net
 
 
   # Create a custom docker network if it does not exist already
 networks:
-  drs-data-dashboard-net:
-    name: drs-data-dashboard-net
+  dashboard-net:
+    name: dashboard-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ version: '3.8'
 
 services:
 
-  drs-data-dashboard:
-    image: registry.lts.harvard.edu/lts/drs-data-dashboard:0.0.3
+  dashboard-ui:
+    image: registry.lts.harvard.edu/lts/dashboard-ui:0.0.1
     build:
       context: .
       dockerfile: DockerfilePub

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,6 +1,6 @@
 [supervisord]
 nodaemon=true
-logfile=/home/appuser/logs/supervisord_drs-data-dashboard.log
+logfile=/home/appuser/logs/supervisord_dashboard-ui.log
 pidfile = /tmp/supervisord.pid
 logfile_maxbytes=50MB
 logfile_backups=10
@@ -11,8 +11,8 @@ directory=/home/appuser
 user=appuser
 autostart=true
 autorestart=true
-stdout_logfile=/home/appuser/logs/supervisord_drs-data-dashboard_stdout.log
-stderr_logfile=/home/appuser/logs/supervisord_drs-data-dashboard_stderr.log
+stdout_logfile=/home/appuser/logs/supervisord_dashboard-ui_stdout.log
+stderr_logfile=/home/appuser/logs/supervisord_dashboard-ui_stderr.log
 stdout_logfile_maxbytes=50MB
 stderr_logfile_maxbytes=50MB
 stdout_logfile_backups=10


### PR DESCRIPTION
**Updating references of drs-data-dashboard to dashboard-ui.**
* * *


# What does this Pull Request do?
I renamed the repository from drs-data-dashboard to dashboard-ui. This PR updates all the references of drs-datadashboard to be dashboard-ui instead.

# How should this be tested?

A description of what steps someone could take to:
* Make sure you have updated your local repository to use dashboard-ui. Either go into your drs-data-dashboard folder and run this command: `git remote set-url origin git@github.com:harvard-lts/dashboard-ui.git` or remove your local repository and re-clone with this command: `git clone git@github.com:harvard-lts/dashboard-ui.git`
* Check out this branch and pull in the changes: `git checkout -b rename-repo` `git pull origin rename-repo`
* Rebuild the container: `docker-compose -f docker-compose-local.yml up -d --build --force-recreate`
* Confirm that the application is still running the same in the browser
* run `docker ps` and confirm the container is running as `dashboard-ui` and not `drs-data-dashboard`
* confirm your log files are named using `dashboard-ui` and not `drs-data-dashboard`
* ssh into the container with this command: `docker exec -it dashboard-ui bash`
* Confirm there are no references to `drs-data-dashboard` in the README or elsewhere in the codebase.

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? No
- integration tests? No

# Interested parties
@enriquediaz @dl-maura @mferrarini @awoods 